### PR TITLE
Fix spinner when jQuery missing

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,15 +1,19 @@
-(function ($) {
+
+(function () {
     "use strict";
 
     // Spinner
     var spinner = function () {
         setTimeout(function () {
-            if ($('#spinner').length > 0) {
-                $('#spinner').removeClass('show');
+            var el = document.getElementById('spinner');
+            if (el) {
+                el.classList.remove('show');
             }
         }, 1);
     };
-    spinner(0);
+    spinner();
+
+    function initJQueryFeatures($) {
     
     
     // Initiate the wowjs
@@ -127,10 +131,16 @@
     }
     });
     $('.back-to-top').click(function () {
-        $('html, body').animate({scrollTop: 0}, 1500, 'easeInOutExpo');
+    $('html, body').animate({scrollTop: 0}, 1500, 'easeInOutExpo');
         return false;
     });
 
 
-})(jQuery);
+    }
+
+    if (typeof window.jQuery !== 'undefined') {
+        initJQueryFeatures(window.jQuery);
+    }
+
+})();
 


### PR DESCRIPTION
## Summary
- remove reliance on jQuery to hide spinner
- run jQuery-based features only if jQuery is present

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557223051083218678439f43c55bae