### PR TITLE
Fix login page styles leaking to other views

### DIFF
--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -2,7 +2,8 @@
 * {
   box-sizing: border-box;
 }
-body {
+/* Restrict styles to login page only */
+.login-body {
   background: #f6f5f7;
   display: flex;
   justify-content: center;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { UserContext } from '../UserContext';
 import './Login.css';
 
@@ -9,6 +9,13 @@ export default function Login() {
   const [signInData, setSignInData] = useState({ email: '', password: '' });
   const [signUpData, setSignUpData] = useState({ name: '', email: '', password: '', code: '' });
   const [verificationStep, setVerificationStep] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.add('login-body');
+    return () => {
+      document.body.classList.remove('login-body');
+    };
+  }, []);
 
   const handleSignIn = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- prevent login page CSS from forcing 100vh layout on all pages
- add body class toggling in the Login component so style only applies while on the login page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685970bc63408321957de3975f0a4f13